### PR TITLE
Fixed bug with black screen during wall collision

### DIFF
--- a/raycaster/game/player.py
+++ b/raycaster/game/player.py
@@ -74,14 +74,23 @@ class Player(Updatable):
         return angle_deg >= fov_start or angle_deg <= fov_end
 
     def check_wall_collision(self, dx: int, dy: int):
+        margin = 5  # margin in pixels
+
+        # Check collision with horizontal walls
         if not self.map.is_wall(
-            int((self.x + dx) / self.settings.CELL_SIZE),
+            int(
+                (self.x + dx + margin * math.copysign(1, dx)) / self.settings.CELL_SIZE
+            ),
             int(self.y / self.settings.CELL_SIZE),
         ):
             self.x += dx
+
+        # Check collision with vertical walls
         if not self.map.is_wall(
             int(self.x / self.settings.CELL_SIZE),
-            int((self.y + dy) / self.settings.CELL_SIZE),
+            int(
+                (self.y + dy + margin * math.copysign(1, dy)) / self.settings.CELL_SIZE
+            ),
         ):
             self.y += dy
 


### PR DESCRIPTION
The error occurred because the player did not move pixel by pixel but by a few pixels (speed), which meant that if a jump of a few pixels (one move) occurred just in front of the wall, he could jump over the texture of the wall and stand in its black center. To prevent this, we check for collisions with the margin to prevent texture jumps.

After testing for a few minutes to see if the error still occurs, I found that this solution is OK.

- A margin variable is defined to specify the distance from the wall at which the player should stop.
- The wall collision check is modified to include this margin. The math.copysign(1, dx) and math.copysign(1, dy) functions are used to ensure the margin is added in the direction of movement

closes #9