### PR TITLE
Adding window manipulation

### DIFF
--- a/raycaster/const.py
+++ b/raycaster/const.py
@@ -6,7 +6,6 @@ from raycaster.core import Settings
 DELTA_ANGLE = math.radians(Settings().FOV / Settings().RAY_COUNT)
 
 # MAP RELATED
-SCREEN_DISTANCE = (
-    (Settings().SCREEN_WIDTH // 2)
-    / math.tan(math.radians(Settings().FOV // 2))
+SCREEN_DISTANCE = (Settings().SCREEN_WIDTH // 2) / math.tan(
+    math.radians(Settings().FOV // 2)
 )

--- a/raycaster/const.py
+++ b/raycaster/const.py
@@ -3,12 +3,11 @@ import math
 from raycaster.core import Settings
 
 # GAME RELATED
-RESOLUTION = Settings().SCREEN_WIDTH, Settings().SCREEN_HEIGHT
+SCREEN_WIDTH = 1280  # Changes over time with resize
+SCREEN_HEIGHT = 720
 
 # PLAYER RELATED
 DELTA_ANGLE = math.radians(Settings().FOV / Settings().RAY_COUNT)
 
 # MAP RELATED
-SCREEN_DISTANCE = (Settings().SCREEN_WIDTH // 2) / math.tan(
-    math.radians(Settings().FOV // 2)
-)
+SCREEN_DISTANCE = (SCREEN_WIDTH // 2) / math.tan(math.radians(Settings().FOV // 2))

--- a/raycaster/const.py
+++ b/raycaster/const.py
@@ -2,12 +2,11 @@ import math
 
 from raycaster.core import Settings
 
-# GAME RELATED
-SCREEN_WIDTH = 1280  # Changes over time with resize
-SCREEN_HEIGHT = 720
-
 # PLAYER RELATED
 DELTA_ANGLE = math.radians(Settings().FOV / Settings().RAY_COUNT)
 
 # MAP RELATED
-SCREEN_DISTANCE = (SCREEN_WIDTH // 2) / math.tan(math.radians(Settings().FOV // 2))
+SCREEN_DISTANCE = (
+    (Settings().SCREEN_WIDTH // 2)
+    / math.tan(math.radians(Settings().FOV // 2))
+)

--- a/raycaster/core/settings.py
+++ b/raycaster/core/settings.py
@@ -2,8 +2,9 @@ class Settings:
     _instance = None
 
     # GAME RELATED
-    SCREEN_WIDTH = 1280
-    SCREEN_HEIGHT = 720
+    FULLSCREEN_MODE = True
+    BASIC_SCREEN_WIDTH = 1280  # For no fullscreen mode
+    BASIC_SCREEN_HEIGHT = 720
 
     CAPTION = "DOOM - demo"
     FPS = 60

--- a/raycaster/core/settings.py
+++ b/raycaster/core/settings.py
@@ -2,9 +2,13 @@ class Settings:
     _instance = None
 
     # GAME RELATED
-    FULLSCREEN_MODE = True
-    BASIC_SCREEN_WIDTH = 1280  # For no fullscreen mode
-    BASIC_SCREEN_HEIGHT = 720
+
+    SCREEN_WIDTH = 1280
+    SCREEN_HEIGHT = 720
+    ORIGINAL_SCREEN_WIDTH = SCREEN_WIDTH
+    ORIGINAL_SCREEN_HEIGHT = SCREEN_HEIGHT
+    FULLSCREEN_MODE = True  # Press F11 to change
+    MINIMIZE_RATIO = 0.5
 
     CAPTION = "DOOM - demo"
     FPS = 60

--- a/raycaster/game/game.py
+++ b/raycaster/game/game.py
@@ -23,7 +23,14 @@ class Game:
             cls.settings = Settings()
             pygame.init()
             pygame.mouse.set_visible(False)
-            cls.screen = pygame.display.set_mode(const.RESOLUTION)
+            if Settings().FULLSCREEN_MODE:
+                cls.screen = pygame.display.set_mode(
+                    (const.SCREEN_WIDTH, const.SCREEN_HEIGHT), pygame.FULLSCREEN
+                )
+            else:
+                cls.screen = pygame.display.set_mode(
+                    (const.SCREEN_WIDTH, const.SCREEN_HEIGHT), pygame.RESIZABLE
+                )
             pygame.display.set_caption(cls.settings.CAPTION)
             cls.delta_time = 1
             cls.clock = pygame.time.Clock()
@@ -48,17 +55,41 @@ class Game:
 
     def handle_events(self):
         """
-        Handles all events.
+        Handling events and switch betwenn screen modes
         """
         for event in pygame.event.get():
-            if event.type == pygame.KEYDOWN and event.key == pygame.K_F4:
-                self.settings.MINIMAP_VISIBLE = not self.settings.MINIMAP_VISIBLE
-
-            if event.type == pygame.QUIT or (
-                event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE
-            ):
+            if event.type == pygame.QUIT:
                 pygame.quit()
                 sys.exit()
+
+            # Window resizing
+            if event.type == pygame.VIDEORESIZE and not Settings().FULLSCREEN_MODE:
+                const.SCREEN_WIDTH, const.SCREEN_HEIGHT = event.w, event.h
+                self.screen = pygame.display.set_mode(
+                    (const.SCREEN_WIDTH, const.SCREEN_HEIGHT), pygame.RESIZABLE
+                )
+
+            if event.type == pygame.KEYDOWN:
+                # Toggle full screen mode
+                if event.key == pygame.K_ESCAPE:
+                    Settings().FULLSCREEN_MODE = not Settings().FULLSCREEN_MODE
+                    if Settings().FULLSCREEN_MODE:
+                        const.SCREEN_WIDTH, const.SCREEN_HEIGHT = (
+                            Settings().BASIC_SCREEN_WIDTH,
+                            Settings().BASIC_SCREEN_HEIGHT,
+                        )  # IMPORTANT line, you need to reset the assignment the event.w and t h event.h to constants, otherwise it will not work
+                        self.screen = pygame.display.set_mode(
+                            (const.SCREEN_WIDTH, const.SCREEN_HEIGHT), pygame.FULLSCREEN
+                        )
+                    else:
+                        self.screen = pygame.display.set_mode(
+                            (const.SCREEN_WIDTH, const.SCREEN_HEIGHT), pygame.RESIZABLE
+                        )
+                elif event.key == pygame.K_F4:
+                    Settings().MINIMAP_VISIBLE = not Settings().MINIMAP_VISIBLE
+
+            # Screen update
+            pygame.display.flip()
 
     def update(self):
         """

--- a/raycaster/game/player.py
+++ b/raycaster/game/player.py
@@ -95,7 +95,7 @@ class Player(Updatable):
         if keys[pygame.K_RIGHT]:
             num_key_pressed += 1
             self.angle += self.sensitivity * self.delta_time
-            self.angle = self.angle % (2 * math.pi)
+            self.angle = self.angle % (2 * math.pi) 
 
     def update(self):
         self.delta_time = self.clock.get_time()

--- a/raycaster/game/player.py
+++ b/raycaster/game/player.py
@@ -95,7 +95,7 @@ class Player(Updatable):
         if keys[pygame.K_RIGHT]:
             num_key_pressed += 1
             self.angle += self.sensitivity * self.delta_time
-            self.angle = self.angle % (2 * math.pi) 
+            self.angle = self.angle % (2 * math.pi)
 
     def update(self):
         self.delta_time = self.clock.get_time()

--- a/raycaster/rendering/gui_renderer.py
+++ b/raycaster/rendering/gui_renderer.py
@@ -65,22 +65,22 @@ class GuiRenderer(Drawable):
     def _draw_minimap(self):
         if self.map.cols > self.map.rows:
             # Map is wider than it is tall
-            mini_map_width = const.SCREEN_WIDTH * self.settings.MINIMAP_RATIO
+            mini_map_width = Settings().SCREEN_WIDTH * self.settings.MINIMAP_RATIO
             mini_map_scale = mini_map_width / self.map.cols
             mini_map_height = mini_map_scale * self.map.rows
         else:
             # Map is taller than it is wide
-            mini_map_height = const.SCREEN_HEIGHT * self.settings.MINIMAP_RATIO
+            mini_map_height = Settings().SCREEN_HEIGHT * self.settings.MINIMAP_RATIO
             mini_map_scale = mini_map_height / self.map.rows
             mini_map_width = mini_map_scale * self.map.cols
 
         mini_map_cell = self.settings.CELL_SIZE / mini_map_scale
 
         mini_map_position_x = (
-            0  # (const.SCREEN_WIDTH - mini_map_width) --> right corner
+            0  # (Settings().SCREEN_WIDTH - mini_map_width) --> right corner
         )
         mini_map_position_y = (
-            0  # (const.SCREEN_HEIGHT - mini_map_height) --> down corner
+            0  # (Settings().SCREEN_HEIGHT - mini_map_height) --> down corner
         )
 
         additional_surface = pygame.Surface(

--- a/raycaster/rendering/gui_renderer.py
+++ b/raycaster/rendering/gui_renderer.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 import pygame
 
 from raycaster.core import Settings, Drawable
+from raycaster import const
 
 if TYPE_CHECKING:
     from raycaster.game import Player, Map
@@ -64,22 +65,22 @@ class GuiRenderer(Drawable):
     def _draw_minimap(self):
         if self.map.cols > self.map.rows:
             # Map is wider than it is tall
-            mini_map_width = self.settings.SCREEN_WIDTH * self.settings.MINIMAP_RATIO
+            mini_map_width = const.SCREEN_WIDTH * self.settings.MINIMAP_RATIO
             mini_map_scale = mini_map_width / self.map.cols
             mini_map_height = mini_map_scale * self.map.rows
         else:
             # Map is taller than it is wide
-            mini_map_height = self.settings.SCREEN_HEIGHT * self.settings.MINIMAP_RATIO
+            mini_map_height = const.SCREEN_HEIGHT * self.settings.MINIMAP_RATIO
             mini_map_scale = mini_map_height / self.map.rows
             mini_map_width = mini_map_scale * self.map.cols
 
         mini_map_cell = self.settings.CELL_SIZE / mini_map_scale
 
         mini_map_position_x = (
-            0  # (self.settings.SCREEN_WIDTH - mini_map_width) --> right corner
+            0  # (const.SCREEN_WIDTH - mini_map_width) --> right corner
         )
         mini_map_position_y = (
-            0  # (self.settings.SCREEN_HEIGHT - mini_map_height) --> down corner
+            0  # (const.SCREEN_HEIGHT - mini_map_height) --> down corner
         )
 
         additional_surface = pygame.Surface(

--- a/raycaster/rendering/object_renderer.py
+++ b/raycaster/rendering/object_renderer.py
@@ -47,17 +47,17 @@ class ObjectRenderer:
         rel_angle = obj.angle - self.player.angle - math.pi
         spatial_width, spatial_height = self._calculate_spatial_dimensions(obj)
         screen_y = (
-            Settings().SCREEN_HEIGHT // 2 - spatial_height // 2
-            if spatial_height <= Settings().SCREEN_HEIGHT
+            const.SCREEN_HEIGHT // 2 - spatial_height // 2
+            if spatial_height <= const.SCREEN_HEIGHT
             else 0
         )
         screen_x = (
             (
                 math.tan(rel_angle) * screen_dist
-                + Settings().SCREEN_WIDTH // 2
+                + const.SCREEN_WIDTH // 2
                 - spatial_width // 2
             )
-            if spatial_width <= Settings().SCREEN_WIDTH
+            if spatial_width <= const.SCREEN_WIDTH
             else math.tan(rel_angle) * screen_dist
         )
         return int(screen_x), int(screen_y)
@@ -66,7 +66,7 @@ class ObjectRenderer:
         """
         Checks if the dimensions are smaller than the screen.
         """
-        return height <= Settings().SCREEN_HEIGHT and width <= Settings().SCREEN_WIDTH
+        return height <= const.SCREEN_HEIGHT and width <= const.SCREEN_WIDTH
 
     def _get_subsurface(
         self, obj: "SpriteObject", sprite: pygame.Surface
@@ -81,11 +81,9 @@ class ObjectRenderer:
         texture_width, texture_height = obj.texture.get_size()
         spatial_width, spatial_height = self._calculate_spatial_dimensions(obj)
 
-        if spatial_width > Settings().SCREEN_WIDTH:
+        if spatial_width > const.SCREEN_WIDTH:
             x_offset = (
-                (spatial_width - Settings().SCREEN_WIDTH)
-                / spatial_width
-                * texture_width
+                (spatial_width - const.SCREEN_WIDTH) / spatial_width * texture_width
             )
             x_start = x_offset / 2
             surface_width = texture_width - x_offset
@@ -93,11 +91,9 @@ class ObjectRenderer:
             x_start = 0
             surface_width = texture_width
 
-        if spatial_height > Settings().SCREEN_HEIGHT:
+        if spatial_height > const.SCREEN_HEIGHT:
             y_offset = (
-                (spatial_height - Settings().SCREEN_HEIGHT)
-                / spatial_height
-                * texture_height
+                (spatial_height - const.SCREEN_HEIGHT) / spatial_height * texture_height
             )
             y_start = y_offset / 2
             surface_height = texture_height - y_offset
@@ -113,10 +109,8 @@ class ObjectRenderer:
         """
         Returns the scaled dimensions of the object based on the spatial dimensions.
         """
-        width = Settings().SCREEN_WIDTH if width > Settings().SCREEN_WIDTH else width
-        height = (
-            Settings().SCREEN_HEIGHT if height > Settings().SCREEN_HEIGHT else height
-        )
+        width = const.SCREEN_WIDTH if width > const.SCREEN_WIDTH else width
+        height = const.SCREEN_HEIGHT if height > const.SCREEN_HEIGHT else height
         return int(width), int(height)
 
     def draw(self, obj: "SpriteObject"):

--- a/raycaster/rendering/object_renderer.py
+++ b/raycaster/rendering/object_renderer.py
@@ -32,8 +32,12 @@ class ObjectRenderer:
         """
         screen_dist = const.SCREEN_DISTANCE
         texture_width, texture_height = obj.texture.get_size()
-        height = screen_dist * texture_height / obj.distance
-        width = screen_dist * texture_width / obj.distance
+        height_scale_factor = (
+            Settings().SCREEN_HEIGHT / Settings().ORIGINAL_SCREEN_HEIGHT
+        )
+        height = (screen_dist * texture_height / obj.distance) * height_scale_factor
+        width_scale_factor = Settings().SCREEN_WIDTH / Settings().ORIGINAL_SCREEN_WIDTH
+        width = (screen_dist * texture_width / obj.distance) * width_scale_factor
         return int(width), int(height)
 
     def _calculate_position_on_screen(self, obj: "SpriteObject") -> tuple[int, int]:
@@ -47,17 +51,17 @@ class ObjectRenderer:
         rel_angle = obj.angle - self.player.angle - math.pi
         spatial_width, spatial_height = self._calculate_spatial_dimensions(obj)
         screen_y = (
-            const.SCREEN_HEIGHT // 2 - spatial_height // 2
-            if spatial_height <= const.SCREEN_HEIGHT
+            Settings().SCREEN_HEIGHT // 2 - spatial_height // 2
+            if spatial_height <= Settings().SCREEN_HEIGHT
             else 0
         )
         screen_x = (
             (
                 math.tan(rel_angle) * screen_dist
-                + const.SCREEN_WIDTH // 2
+                + Settings().SCREEN_WIDTH // 2
                 - spatial_width // 2
             )
-            if spatial_width <= const.SCREEN_WIDTH
+            if spatial_width <= Settings().SCREEN_WIDTH
             else math.tan(rel_angle) * screen_dist
         )
         return int(screen_x), int(screen_y)
@@ -66,7 +70,7 @@ class ObjectRenderer:
         """
         Checks if the dimensions are smaller than the screen.
         """
-        return height <= const.SCREEN_HEIGHT and width <= const.SCREEN_WIDTH
+        return height <= Settings().SCREEN_HEIGHT and width <= Settings().SCREEN_WIDTH
 
     def _get_subsurface(
         self, obj: "SpriteObject", sprite: pygame.Surface
@@ -81,9 +85,11 @@ class ObjectRenderer:
         texture_width, texture_height = obj.texture.get_size()
         spatial_width, spatial_height = self._calculate_spatial_dimensions(obj)
 
-        if spatial_width > const.SCREEN_WIDTH:
+        if spatial_width > Settings().SCREEN_WIDTH:
             x_offset = (
-                (spatial_width - const.SCREEN_WIDTH) / spatial_width * texture_width
+                (spatial_width - Settings().SCREEN_WIDTH)
+                / spatial_width
+                * texture_width
             )
             x_start = x_offset / 2
             surface_width = texture_width - x_offset
@@ -91,9 +97,11 @@ class ObjectRenderer:
             x_start = 0
             surface_width = texture_width
 
-        if spatial_height > const.SCREEN_HEIGHT:
+        if spatial_height > Settings().SCREEN_HEIGHT:
             y_offset = (
-                (spatial_height - const.SCREEN_HEIGHT) / spatial_height * texture_height
+                (spatial_height - Settings().SCREEN_HEIGHT)
+                / spatial_height
+                * texture_height
             )
             y_start = y_offset / 2
             surface_height = texture_height - y_offset
@@ -109,8 +117,10 @@ class ObjectRenderer:
         """
         Returns the scaled dimensions of the object based on the spatial dimensions.
         """
-        width = const.SCREEN_WIDTH if width > const.SCREEN_WIDTH else width
-        height = const.SCREEN_HEIGHT if height > const.SCREEN_HEIGHT else height
+        width = Settings().SCREEN_WIDTH if width > Settings().SCREEN_WIDTH else width
+        height = (
+            Settings().SCREEN_HEIGHT if height > Settings().SCREEN_HEIGHT else height
+        )
         return int(width), int(height)
 
     def draw(self, obj: "SpriteObject"):

--- a/raycaster/rendering/world_renderer.py
+++ b/raycaster/rendering/world_renderer.py
@@ -35,10 +35,9 @@ class WorldRenderer(Drawable):
         """
         Draws the background with gradient shading in the centre.
         """
-        for row in range(self.settings.SCREEN_HEIGHT // 2):
+        for row in range(const.SCREEN_HEIGHT // 2):
             shade_factor = (
-                (self.settings.SCREEN_HEIGHT // 2 - row)
-                / (self.settings.SCREEN_HEIGHT // 2)
+                (const.SCREEN_HEIGHT // 2 - row) / (const.SCREEN_HEIGHT // 2)
             ) ** 2
             pygame.draw.line(
                 self.screen,
@@ -48,13 +47,12 @@ class WorldRenderer(Drawable):
                     int(50) * shade_factor,
                 ),
                 (0, row),
-                (self.settings.SCREEN_WIDTH, row),
+                (const.SCREEN_WIDTH, row),
                 1,
             )
-        for row in range(self.settings.SCREEN_HEIGHT // 2, self.settings.SCREEN_HEIGHT):
+        for row in range(const.SCREEN_HEIGHT // 2, const.SCREEN_HEIGHT):
             shade_factor = (
-                (row - self.settings.SCREEN_HEIGHT // 2)
-                / (self.settings.SCREEN_HEIGHT // 2)
+                (row - const.SCREEN_HEIGHT // 2) / (const.SCREEN_HEIGHT // 2)
             ) ** 2
             pygame.draw.line(
                 self.screen,
@@ -64,7 +62,7 @@ class WorldRenderer(Drawable):
                     int(30) * shade_factor,
                 ),
                 (0, row),
-                (self.settings.SCREEN_WIDTH, row),
+                (const.SCREEN_WIDTH, row),
                 1,
             )
 
@@ -82,7 +80,7 @@ class WorldRenderer(Drawable):
 
         screen_dist = const.SCREEN_DISTANCE
         ray_count = self.settings.RAY_COUNT
-        column_width = math.ceil(self.settings.SCREEN_WIDTH / ray_count)
+        column_width = math.ceil(const.SCREEN_WIDTH / ray_count)
 
         wall_texture = self.wall_textures[ray.texture_id]
 
@@ -94,19 +92,17 @@ class WorldRenderer(Drawable):
         )
         texture_height = wall_texture.get_height()
 
-        if height <= self.settings.SCREEN_HEIGHT:
+        if height <= const.SCREEN_HEIGHT:
             column = wall_texture.subsurface(x_offset, 0, 1, texture_height)
             column = pygame.transform.scale(column, (column_width, height))
-            y_pos = self.settings.SCREEN_HEIGHT / 2 - height / 2
+            y_pos = const.SCREEN_HEIGHT / 2 - height / 2
         else:
-            y_offset = height - self.settings.SCREEN_HEIGHT
+            y_offset = height - const.SCREEN_HEIGHT
             y_offset = y_offset / height * self.settings.CELL_SIZE
             column = wall_texture.subsurface(
                 x_offset, y_offset / 2, 1, self.settings.CELL_SIZE - y_offset
             )
-            column = pygame.transform.scale(
-                column, (column_width, self.settings.SCREEN_HEIGHT)
-            )
+            column = pygame.transform.scale(column, (column_width, const.SCREEN_HEIGHT))
             y_pos = 0
 
         shade = calculate_shade_factor(ray.length)
@@ -135,9 +131,5 @@ class WorldRenderer(Drawable):
                 object_renderer.draw(obj)
 
     def draw(self):
-        """
-        TODO: Find out why sometimes(very often) screen turns black when player run into wall and fix this.
-        (objection: isn't it because of the player's falling into the wall? perhaps we should check wall hitbox)
-        """
         self._draw_background()
         self._draw_world()

--- a/raycaster/rendering/world_renderer.py
+++ b/raycaster/rendering/world_renderer.py
@@ -35,9 +35,9 @@ class WorldRenderer(Drawable):
         """
         Draws the background with gradient shading in the centre.
         """
-        for row in range(const.SCREEN_HEIGHT // 2):
+        for row in range(Settings().SCREEN_HEIGHT // 2):
             shade_factor = (
-                (const.SCREEN_HEIGHT // 2 - row) / (const.SCREEN_HEIGHT // 2)
+                (Settings().SCREEN_HEIGHT // 2 - row) / (Settings().SCREEN_HEIGHT // 2)
             ) ** 2
             pygame.draw.line(
                 self.screen,
@@ -47,12 +47,12 @@ class WorldRenderer(Drawable):
                     int(50) * shade_factor,
                 ),
                 (0, row),
-                (const.SCREEN_WIDTH, row),
+                (Settings().SCREEN_WIDTH, row),
                 1,
             )
-        for row in range(const.SCREEN_HEIGHT // 2, const.SCREEN_HEIGHT):
+        for row in range(Settings().SCREEN_HEIGHT // 2, Settings().SCREEN_HEIGHT):
             shade_factor = (
-                (row - const.SCREEN_HEIGHT // 2) / (const.SCREEN_HEIGHT // 2)
+                (row - Settings().SCREEN_HEIGHT // 2) / (Settings().SCREEN_HEIGHT // 2)
             ) ** 2
             pygame.draw.line(
                 self.screen,
@@ -62,7 +62,7 @@ class WorldRenderer(Drawable):
                     int(30) * shade_factor,
                 ),
                 (0, row),
-                (const.SCREEN_WIDTH, row),
+                (Settings().SCREEN_WIDTH, row),
                 1,
             )
 
@@ -80,11 +80,17 @@ class WorldRenderer(Drawable):
 
         screen_dist = const.SCREEN_DISTANCE
         ray_count = self.settings.RAY_COUNT
-        column_width = math.ceil(const.SCREEN_WIDTH / ray_count)
+        column_width = math.ceil(Settings().SCREEN_WIDTH / ray_count)
 
         wall_texture = self.wall_textures[ray.texture_id]
 
-        height = screen_dist * self.settings.CELL_SIZE / ray.length
+        height_scale_factor = (
+            Settings().SCREEN_HEIGHT / Settings().ORIGINAL_SCREEN_HEIGHT
+        )
+        height = (
+            screen_dist * self.settings.CELL_SIZE / ray.length
+        ) * height_scale_factor
+
         x_offset = (
             (ray.x_end % self.settings.CELL_SIZE)
             if ray.is_horizontal
@@ -92,17 +98,19 @@ class WorldRenderer(Drawable):
         )
         texture_height = wall_texture.get_height()
 
-        if height <= const.SCREEN_HEIGHT:
+        if height <= Settings().SCREEN_HEIGHT:
             column = wall_texture.subsurface(x_offset, 0, 1, texture_height)
             column = pygame.transform.scale(column, (column_width, height))
-            y_pos = const.SCREEN_HEIGHT / 2 - height / 2
+            y_pos = Settings().SCREEN_HEIGHT / 2 - height / 2
         else:
-            y_offset = height - const.SCREEN_HEIGHT
+            y_offset = height - Settings().SCREEN_HEIGHT
             y_offset = y_offset / height * self.settings.CELL_SIZE
             column = wall_texture.subsurface(
                 x_offset, y_offset / 2, 1, self.settings.CELL_SIZE - y_offset
             )
-            column = pygame.transform.scale(column, (column_width, const.SCREEN_HEIGHT))
+            column = pygame.transform.scale(
+                column, (column_width, Settings().SCREEN_HEIGHT)
+            )
             y_pos = 0
 
         shade = calculate_shade_factor(ray.length)


### PR DESCRIPTION
Adding window manipulation
- For this to work properly, we need 2 types of variables **SCREEN_WIDTH, SCREEN_HEIGHT** in const.py file which change over time in resizing process and **BASIC_SCREEN_WIDTH = 1280, BASIC_SCREEN_HEIGHT = 720**, which we need to reset the state of the variables when switching to full screen mode after changing sizes windows
- **RESOLUTION** is useless because if we will change it with SCREEN_WIDTH, SCREEN_HEIGHT resizing does not work properly
- Pygame has a some type of variable cache that causes a lot of problems in this process, several people have written about it on the internet. this causes some problems and that's why after a few tries this option seems to be the best

![Screenshot 2023-12-11 205956](https://github.com/pietrykovsky/python-raycaster/assets/93057795/462f5c56-5c50-4c17-a6f7-0be6c9353eeb)
![Screenshot 2023-12-11 210032](https://github.com/pietrykovsky/python-raycaster/assets/93057795/19619e9d-f8c5-4368-a800-fb07abc40520)

closes #22 